### PR TITLE
enforce user status check on login and refresh

### DIFF
--- a/backend/platform/identity/auth/auth_service.rs
+++ b/backend/platform/identity/auth/auth_service.rs
@@ -159,6 +159,10 @@ impl Service {
             .reset_failed_login_count(&self.context.db, record.user.tenant_id, record.user.id)
             .await?;
 
+        if record.user.status != users::UserStatus::Active {
+            return Err(Error::InvalidCredentials);
+        }
+
         if crypto::needs_rehash(password_hash)? {
             self.update_password_hash(record.user.tenant_id, record.user.id, &command.password)
                 .await;
@@ -177,6 +181,9 @@ impl Service {
             sso_id: command.sso_id,
         };
         let user = self.users.link_sso_user(&self.context.db, cmd).await?;
+        if user.status != users::UserStatus::Active {
+            return Err(Error::InvalidCredentials);
+        }
         self.users
             .reset_failed_login_count(&self.context.db, user.tenant_id, user.id)
             .await?;
@@ -253,6 +260,9 @@ impl Service {
             .users
             .find_by_id(&self.context.db, tenant_id, stored_token.user_id)
             .await?;
+        if user.status != users::UserStatus::Active {
+            return Err(Error::InvalidToken);
+        }
         let access_token = generate_access_token(&self.context, &user)?;
         let refresh_token = generate_refresh_token(&self.context, &user)?;
         let refresh_token_hash = crypto::get_hash_as_hex(&refresh_token.value);

--- a/backend/platform/identity/auth/auth_tests.rs
+++ b/backend/platform/identity/auth/auth_tests.rs
@@ -72,7 +72,7 @@ async fn oauth_user_linking_existing_password_user() -> TestResult {
     let res = auth_service.login_oauth(command).await?;
     assert_eq!(res.user.id, user.id);
 
-    // Query DB to verify SSO info was linked
+    // query DB to verify SSO info was linked
     let sso_info_after = users::db::Repository.find_sso_info_by_id(&ctx.db, user.id).await?;
     assert_eq!(sso_info_after.sso_provider, Some("google".to_string()));
     assert_eq!(sso_info_after.sso_id, Some("google-linked-id".to_string()));
@@ -126,12 +126,12 @@ async fn suspended_user_login_and_refresh_failure() -> TestResult {
         .register(
             email.clone(),
             "super_secure_pass_123".to_string(),
-            Some("Suspended".to_string()),
-            Some("User".to_string()),
+            Some("John".to_string()),
+            Some("Wick".to_string()),
         )
         .await?;
 
-    // Initial login should succeed when user is active
+    // initial login should succeed when user is active
     let login_cmd = auth::LoginCommand {
         email: email.clone(),
         password: "super_secure_pass_123".to_string(),
@@ -139,18 +139,18 @@ async fn suspended_user_login_and_refresh_failure() -> TestResult {
     let auth_res = auth_service.login(login_cmd.clone()).await?;
     assert_eq!(auth_res.user.id, user.id);
 
-    // Now suspend the user in the database
+    // now suspend the user in the database
     sqlx::query("UPDATE users SET status = 'suspended' WHERE id = ?")
         .bind(user.id.0)
         .execute(&ctx.db)
         .await?;
 
-    // Subsequent login should fail
+    // subsequent login should fail
     let login_err = auth_service.login(login_cmd).await;
     assert!(login_err.is_err());
     assert!(matches!(login_err, Err(auth::Error::InvalidCredentials)));
 
-    // Refresh should fail
+    // refresh should fail
     let refresh_err = auth_service.refresh(&auth_res.refresh_token.value).await;
     assert!(refresh_err.is_err());
     assert!(matches!(refresh_err, Err(auth::Error::InvalidToken)));

--- a/backend/platform/identity/auth/auth_tests.rs
+++ b/backend/platform/identity/auth/auth_tests.rs
@@ -115,3 +115,45 @@ async fn oauth_user_password_login_failure() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn suspended_user_login_and_refresh_failure() -> TestResult {
+    let ctx = common::Context::create_test_context().await?;
+    let auth_service = auth::Service::new(users::db::Repository, tokens::db::Repository, ctx.clone());
+
+    let email = common::Email::parse("suspended@example.com").ok_or_else(api::Error::invalid_credentials)?;
+    let user = auth_service
+        .register(
+            email.clone(),
+            "super_secure_pass_123".to_string(),
+            Some("Suspended".to_string()),
+            Some("User".to_string()),
+        )
+        .await?;
+
+    // Initial login should succeed when user is active
+    let login_cmd = auth::LoginCommand {
+        email: email.clone(),
+        password: "super_secure_pass_123".to_string(),
+    };
+    let auth_res = auth_service.login(login_cmd.clone()).await?;
+    assert_eq!(auth_res.user.id, user.id);
+
+    // Now suspend the user in the database
+    sqlx::query("UPDATE users SET status = 'suspended' WHERE id = ?")
+        .bind(user.id.0)
+        .execute(&ctx.db)
+        .await?;
+
+    // Subsequent login should fail
+    let login_err = auth_service.login(login_cmd).await;
+    assert!(login_err.is_err());
+    assert!(matches!(login_err, Err(auth::Error::InvalidCredentials)));
+
+    // Refresh should fail
+    let refresh_err = auth_service.refresh(&auth_res.refresh_token.value).await;
+    assert!(refresh_err.is_err());
+    assert!(matches!(refresh_err, Err(auth::Error::InvalidToken)));
+
+    Ok(())
+}


### PR DESCRIPTION
### Location
- backend/platform/identity/auth/auth_service.rs
- backend/platform/identity/auth/auth_tests.rs

### Finding
login and refresh never check user.status. A user who is suspended or archived can still log in with a valid password, and existing refresh tokens keep minting new access tokens. The status field exists in the schema and domain model but is never enforced.

### Risk
Account suspension is a core security control (offboarding, abuse response, ban enforcement). Today it is cosmetic — suspending a user does nothing.

### Recommendation
After a successful credential/refresh check, reject non-Active statuses with Error::InvalidCredentials (login) / Error::InvalidToken (refresh). On suspend/archive, also revoke all refresh tokens (revoke_all_for_user). Add tests for "suspended user cannot log in" and "suspended user's refresh token is rejected."