### PR TITLE
enforce global request body limit and body length constraints

### DIFF
--- a/backend/platform/identity/auth/auth_api.rs
+++ b/backend/platform/identity/auth/auth_api.rs
@@ -36,13 +36,23 @@ pub fn router(service: auth::Service) -> utoipax::router::OpenApiRouter<common::
 
 #[derive(Deserialize, validator::Validate, utoipa::ToSchema)]
 pub struct RegisterRequest {
-    #[validate(email(message = "invalid email address"))]
-    #[schema(example = "alice@example.com", format = "email")]
+    #[validate(
+        email(message = "invalid email address"),
+        length(max = 254, message = "email address must be 254 characters or less")
+    )]
+    #[schema(example = "alice@example.com", format = "email", max_length = 254)]
     pub email: String,
-    #[validate(length(min = 8, message = "password must be at least 8 characters"))]
-    #[schema(min_length = 8)]
+
+    #[validate(length(min = 8, max = 72, message = "password must be between 8 and 72 characters"))]
+    #[schema(min_length = 8, max_length = 72)]
     pub password: String,
+
+    #[validate(length(max = 100, message = "first name must be 100 characters or less"))]
+    #[schema(max_length = 100)]
     pub first_name: Option<String>,
+
+    #[validate(length(max = 100, message = "last name must be 100 characters or less"))]
+    #[schema(max_length = 100)]
     pub last_name: Option<String>,
 }
 
@@ -51,10 +61,17 @@ pub struct RegisterResponse {
     pub user: users::api::UserInfo,
 }
 
-#[derive(Deserialize, utoipa::ToSchema)]
+#[derive(Deserialize, validator::Validate, utoipa::ToSchema)]
 pub struct LoginRequest {
-    #[schema(example = "alice@example.com", format = "email")]
+    #[validate(
+        email(message = "invalid email address"),
+        length(max = 254, message = "email address must be 254 characters or less")
+    )]
+    #[schema(example = "alice@example.com", format = "email", max_length = 254)]
     pub email: String,
+
+    #[validate(length(min = 8, max = 72, message = "password must be between 8 and 72 characters"))]
+    #[schema(min_length = 8, max_length = 72)]
     pub password: String,
 }
 
@@ -100,12 +117,13 @@ async fn register(
     request_body = LoginRequest,
     responses(
         (status = 200, description = "Login successful", body = LoginResponse),
+        (status = 400, description = "Validation failed", body = api::Error),
         (status = 401, description = "Invalid credentials", body = api::Error)
     )
 )]
 async fn login(
     State(service): State<auth::Service>,
-    request: api::Json<LoginRequest>,
+    request: api::ValidatedJson<LoginRequest>,
 ) -> Result<impl IntoResponse, api::Error> {
     let request = request.data();
     let email_hash = crypto::get_hash_as_hex(&request.email);

--- a/backend/platform/identity/auth/auth_service.rs
+++ b/backend/platform/identity/auth/auth_service.rs
@@ -159,6 +159,10 @@ impl Service {
             .reset_failed_login_count(&self.context.db, record.user.tenant_id, record.user.id)
             .await?;
 
+        if record.user.status != users::UserStatus::Active {
+            return Err(Error::InvalidCredentials);
+        }
+
         if crypto::needs_rehash(password_hash)? {
             self.update_password_hash(record.user.tenant_id, record.user.id, &command.password)
                 .await;
@@ -177,6 +181,9 @@ impl Service {
             sso_id: command.sso_id,
         };
         let user = self.users.link_sso_user(&self.context.db, cmd).await?;
+        if user.status != users::UserStatus::Active {
+            return Err(Error::InvalidCredentials);
+        }
         self.users
             .reset_failed_login_count(&self.context.db, user.tenant_id, user.id)
             .await?;
@@ -253,6 +260,9 @@ impl Service {
             .users
             .find_by_id(&self.context.db, tenant_id, stored_token.user_id)
             .await?;
+        if user.status != users::UserStatus::Active {
+            return Err(Error::InvalidToken);
+        }
         let access_token = generate_access_token(&self.context, &user)?;
         let refresh_token = generate_refresh_token(&self.context, &user)?;
         let refresh_token_hash = crypto::get_hash_as_hex(&refresh_token.value);

--- a/backend/platform/identity/auth/auth_tests.rs
+++ b/backend/platform/identity/auth/auth_tests.rs
@@ -115,3 +115,45 @@ async fn oauth_user_password_login_failure() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn suspended_user_login_and_refresh_failure() -> TestResult {
+    let ctx = common::Context::create_test_context().await?;
+    let auth_service = auth::Service::new(users::db::Repository, tokens::db::Repository, ctx.clone());
+
+    let email = common::Email::parse("suspended@example.com").ok_or_else(api::Error::invalid_credentials)?;
+    let user = auth_service
+        .register(
+            email.clone(),
+            "super_secure_pass_123".to_string(),
+            Some("Suspended".to_string()),
+            Some("User".to_string()),
+        )
+        .await?;
+
+    // Initial login should succeed when user is active
+    let login_cmd = auth::LoginCommand {
+        email: email.clone(),
+        password: "super_secure_pass_123".to_string(),
+    };
+    let auth_res = auth_service.login(login_cmd.clone()).await?;
+    assert_eq!(auth_res.user.id, user.id);
+
+    // Now suspend the user in the database
+    sqlx::query("UPDATE users SET status = 'suspended' WHERE id = ?")
+        .bind(user.id.0)
+        .execute(&ctx.db)
+        .await?;
+
+    // Subsequent login should fail
+    let login_err = auth_service.login(login_cmd).await;
+    assert!(login_err.is_err());
+    assert!(matches!(login_err, Err(auth::Error::InvalidCredentials)));
+
+    // Refresh should fail
+    let refresh_err = auth_service.refresh(&auth_res.refresh_token.value).await;
+    assert!(refresh_err.is_err());
+    assert!(matches!(refresh_err, Err(auth::Error::InvalidToken)));
+
+    Ok(())
+}

--- a/backend/platform/shared/api.rs
+++ b/backend/platform/shared/api.rs
@@ -244,6 +244,7 @@ where
 pub struct Json<T>(pub T);
 
 impl<T> Json<T> {
+    #[allow(dead_code)]
     pub fn data(self) -> T {
         self.0
     }

--- a/backend/platform/shared/api.rs
+++ b/backend/platform/shared/api.rs
@@ -243,13 +243,6 @@ where
 /// deserialization/parsing errors and return them as a structured `api::Error`.
 pub struct Json<T>(pub T);
 
-impl<T> Json<T> {
-    #[allow(dead_code)]
-    pub fn data(self) -> T {
-        self.0
-    }
-}
-
 impl<T> From<T> for Json<T> {
     fn from(value: T) -> Self {
         Self(value)

--- a/backend/platform/shared/config.rs
+++ b/backend/platform/shared/config.rs
@@ -121,6 +121,9 @@ pub struct ServerSettings {
 
     #[serde(default)]
     pub env_vars_prefix: String,
+
+    #[serde(default)]
+    pub trusted_proxy: bool,
 }
 
 impl Default for ServerSettings {
@@ -131,6 +134,7 @@ impl Default for ServerSettings {
             port: 3000,
             log_directives: "info,tower_http=info,axum=info".to_string(),
             env_vars_prefix: "APP".to_string(),
+            trusted_proxy: false,
         }
     }
 }

--- a/backend/platform/shared/rate_limiter.rs
+++ b/backend/platform/shared/rate_limiter.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use axum::http::Request;
 use axum::response::IntoResponse;
@@ -27,6 +28,7 @@ impl tower_governor::key_extractor::KeyExtractor for ClientIpExtractor {
 
 pub static GLOBAL_LIMITER_CONFIG: OnceLock<Arc<GovernorConfig<ClientIpExtractor, NoOpMiddleware>>> = OnceLock::new();
 pub static LOGIN_LIMITER_CONFIG: OnceLock<Arc<GovernorConfig<ClientIpExtractor, NoOpMiddleware>>> = OnceLock::new();
+pub static TRUSTED_PROXY: AtomicBool = AtomicBool::new(false);
 
 pub fn add_global_rate_limiting<S>(
     router: utoipax::router::OpenApiRouter<S>,
@@ -82,18 +84,20 @@ pub fn custom_error_handler(_err: GovernorError) -> Response {
 
 #[must_use]
 pub fn extract_client_ip<B>(req: &Request<B>) -> String {
-    // check common proxy headers
-    if let Some(forwarded_for) = req.headers().get("x-forwarded-for")
-        && let Ok(value) = forwarded_for.to_str()
-        && let Some(ip) = value.split(',').next()
-    {
-        return ip.trim().to_string();
-    }
+    if TRUSTED_PROXY.load(Ordering::Relaxed) {
+        // check common proxy headers
+        if let Some(forwarded_for) = req.headers().get("x-forwarded-for")
+            && let Ok(value) = forwarded_for.to_str()
+            && let Some(ip) = value.split(',').next()
+        {
+            return ip.trim().to_string();
+        }
 
-    if let Some(real_ip) = req.headers().get("x-real-ip")
-        && let Ok(value) = real_ip.to_str()
-    {
-        return value.to_string();
+        if let Some(real_ip) = req.headers().get("x-real-ip")
+            && let Ok(value) = real_ip.to_str()
+        {
+            return value.to_string();
+        }
     }
 
     // fallback to Axum's SocketAddr ConnectInfo

--- a/backend/router.rs
+++ b/backend/router.rs
@@ -74,6 +74,7 @@ pub fn create(context: ArcContext) -> OpenApiRouter {
             }),
         )
         .layer(tower_http::catch_panic::CatchPanicLayer::custom(CustomPanicHandler))
+        .layer(axum::middleware::from_fn(security_headers_middleware))
         .with_state(context)
 }
 
@@ -180,4 +181,41 @@ fn extract_user_agent(req: &Request<Body>) -> Option<String> {
         .get("user-agent")
         .and_then(|ua| ua.to_str().ok())
         .map(std::string::ToString::to_string)
+}
+
+async fn security_headers_middleware(
+    req: Request<Body>,
+    next: axum::middleware::Next,
+) -> Response {
+    let mut res = next.run(req).await;
+    let headers = res.headers_mut();
+
+    headers.insert(
+        axum::http::header::X_CONTENT_TYPE_OPTIONS,
+        axum::http::HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        axum::http::header::X_FRAME_OPTIONS,
+        axum::http::HeaderValue::from_static("DENY"),
+    );
+    headers.insert(
+        axum::http::header::REFERRER_POLICY,
+        axum::http::HeaderValue::from_static("strict-origin-when-cross-origin"),
+    );
+    headers.insert(
+        axum::http::header::CONTENT_SECURITY_POLICY,
+        axum::http::HeaderValue::from_static(
+            "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'none';",
+        ),
+    );
+    headers.insert(
+        axum::http::header::STRICT_TRANSPORT_SECURITY,
+        axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+    );
+    headers.insert(
+        axum::http::header::HeaderName::from_static("permissions-policy"),
+        axum::http::HeaderValue::from_static("geolocation=(), microphone=(), camera=()"),
+    );
+
+    res
 }

--- a/backend/router.rs
+++ b/backend/router.rs
@@ -75,6 +75,7 @@ pub fn create(context: ArcContext) -> OpenApiRouter {
         )
         .layer(tower_http::catch_panic::CatchPanicLayer::custom(CustomPanicHandler))
         .layer(axum::middleware::from_fn(security_headers_middleware))
+        .layer(axum::extract::DefaultBodyLimit::max(2 * 1024 * 1024))
         .with_state(context)
 }
 

--- a/backend/router.rs
+++ b/backend/router.rs
@@ -27,6 +27,11 @@ pub fn create(context: ArcContext) -> OpenApiRouter {
     use crate::platform::identity::tokens;
     use crate::platform::identity::users;
 
+    rate_limiter::TRUSTED_PROXY.store(
+        context.settings.server.trusted_proxy,
+        std::sync::atomic::Ordering::Relaxed,
+    );
+
     let auth_service = auth::Service::new(users::db::Repository, tokens::db::Repository, context.clone());
     let oauth_service = oauth::Service::new(context.clone(), auth_service.clone());
     let users_service = users::Service::new(users::db::Repository, context.clone());

--- a/backend/test/platform/identity/auth_tests.rs
+++ b/backend/test/platform/identity/auth_tests.rs
@@ -429,7 +429,10 @@ async fn register_invalid_password() -> TestResult {
     response.assert_status(StatusCode::BAD_REQUEST);
     let r: Value = response.json();
     assert_eq!(r["code"], "validation_failed");
-    assert_eq!(r["details"]["password"][0], "password must be at least 8 characters");
+    assert_eq!(
+        r["details"]["password"][0],
+        "password must be between 8 and 72 characters"
+    );
     Ok(())
 }
 

--- a/backend/test/platform/shared/rate_limiter_tests.rs
+++ b/backend/test/platform/shared/rate_limiter_tests.rs
@@ -14,19 +14,35 @@ use crate::platform::rate_limiter::extract_client_ip;
 
 #[test]
 fn test_extract_client_ip() -> Result<(), axum::http::Error> {
-    // test X-Forwarded-For header
+    use std::sync::atomic::Ordering;
+
+    // By default, trusted_proxy is false
+    crate::platform::rate_limiter::TRUSTED_PROXY.store(false, Ordering::Relaxed);
+
+    // test headers ignored when trusted_proxy is false
     let req1 = Request::builder()
         .header("x-forwarded-for", "203.0.113.195, 70.41.3.18, 150.172.238.178")
         .body(())?;
-    assert_eq!(extract_client_ip(&req1), "203.0.113.195");
+    assert_eq!(extract_client_ip(&req1), "unknown");
 
-    // test X-Real-IP header
     let req2 = Request::builder().header("x-real-ip", "203.0.113.196").body(())?;
-    assert_eq!(extract_client_ip(&req2), "203.0.113.196");
+    assert_eq!(extract_client_ip(&req2), "unknown");
+
+    // Enable trusted proxy
+    crate::platform::rate_limiter::TRUSTED_PROXY.store(true, Ordering::Relaxed);
+
+    // test headers honored when trusted_proxy is true
+    let req3 = Request::builder()
+        .header("x-forwarded-for", "203.0.113.195, 70.41.3.18, 150.172.238.178")
+        .body(())?;
+    assert_eq!(extract_client_ip(&req3), "203.0.113.195");
+
+    let req4 = Request::builder().header("x-real-ip", "203.0.113.196").body(())?;
+    assert_eq!(extract_client_ip(&req4), "203.0.113.196");
 
     // test fallback
-    let req3 = Request::builder().body(())?;
-    assert_eq!(extract_client_ip(&req3), "unknown");
+    let req5 = Request::builder().body(())?;
+    assert_eq!(extract_client_ip(&req5), "unknown");
     Ok(())
 }
 

--- a/backend/test/test_server.rs
+++ b/backend/test/test_server.rs
@@ -166,3 +166,46 @@ async fn test_security_headers() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_request_validation() -> TestResult {
+    let server = create_test_server().await?;
+
+    // test password too short in registration (should be 400 Bad Request)
+    let response = server
+        .post("/api/auth/register")
+        .json(&json!({
+            "email": "valid@example.com",
+            "password": "short", // < 8 characters
+            "first_name": "Test",
+            "last_name": "User"
+        }))
+        .await;
+    response.assert_status(StatusCode::BAD_REQUEST);
+    let body: Value = response.json();
+    assert_eq!(body["code"], "validation_failed");
+
+    // test password too long in registration (should be 400 Bad Request)
+    let response_long = server
+        .post("/api/auth/register")
+        .json(&json!({
+            "email": "valid@example.com",
+            "password": "a".repeat(73), // > 72 characters
+            "first_name": "Test",
+            "last_name": "User"
+        }))
+        .await;
+    response_long.assert_status(StatusCode::BAD_REQUEST);
+
+    // test password too long in login (should be 400 Bad Request)
+    let response_login = server
+        .post("/api/auth/login")
+        .json(&json!({
+            "email": "valid@example.com",
+            "password": "a".repeat(73), // > 72 characters
+        }))
+        .await;
+    response_login.assert_status(StatusCode::BAD_REQUEST);
+
+    Ok(())
+}

--- a/backend/test/test_server.rs
+++ b/backend/test/test_server.rs
@@ -143,3 +143,26 @@ async fn test_panic_handling() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_security_headers() -> TestResult {
+    let server = create_test_server().await?;
+
+    let response = server.get("/api/health").await;
+    response.assert_status(StatusCode::OK);
+
+    response.assert_header(axum::http::header::X_CONTENT_TYPE_OPTIONS, "nosniff");
+    response.assert_header(axum::http::header::X_FRAME_OPTIONS, "DENY");
+    response.assert_header(axum::http::header::REFERRER_POLICY, "strict-origin-when-cross-origin");
+    response.assert_header(
+        axum::http::header::CONTENT_SECURITY_POLICY,
+        "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'none';"
+    );
+    response.assert_header(
+        axum::http::header::STRICT_TRANSPORT_SECURITY,
+        "max-age=31536000; includeSubDomains",
+    );
+    response.assert_header("permissions-policy", "geolocation=(), microphone=(), camera=()");
+
+    Ok(())
+}

--- a/data/configs.common.toml
+++ b/data/configs.common.toml
@@ -4,6 +4,7 @@ host = "127.0.0.1"
 port = 3000
 log_directives = "debug,tower_http=debug,axum=debug"
 env_vars_prefix = "APP" # customizable prefix used for the environment variables that override the values provided in the config file
+trusted_proxy = false
 
 [database]
 url = "sqlite:data/db.sqlite"

--- a/data/configs.development.toml
+++ b/data/configs.development.toml
@@ -4,6 +4,7 @@ host = "127.0.0.1"
 port = 3000
 log_directives = "debug,tower_http=debug,axum=debug"
 env_vars_prefix = "APP" # customizable prefix used for the environment variables that override the values provided in the config file
+trusted_proxy = false
 
 [database]
 url = "sqlite:data/db.sqlite"

--- a/data/configs.production.toml
+++ b/data/configs.production.toml
@@ -4,6 +4,7 @@ host = "0.0.0.0"
 port = 3000
 log_directives = "info,tower_http=warn,axum=warn"
 env_vars_prefix = "APP" # customizable prefix used for the environment variables that override the values provided in the config file
+trusted_proxy = false
 
 [database]
 url = "sqlite:data/db.sqlite"

--- a/frontend/src/lib/generated/api.d.ts
+++ b/frontend/src/lib/generated/api.d.ts
@@ -299,6 +299,15 @@ export interface operations {
                     'application/json': components['schemas']['LoginResponse'];
                 };
             };
+            /** @description Validation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    'application/json': components['schemas']['ApiError'];
+                };
+            };
             /** @description Invalid credentials */
             401: {
                 headers: {

--- a/openapi.json
+++ b/openapi.json
@@ -55,6 +55,16 @@
               }
             }
           },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Invalid credentials",
             "content": {
@@ -490,10 +500,13 @@
           "email": {
             "type": "string",
             "format": "email",
-            "example": "alice@example.com"
+            "example": "alice@example.com",
+            "maxLength": 254
           },
           "password": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 72,
+            "minLength": 8
           }
         }
       },
@@ -541,22 +554,26 @@
           "email": {
             "type": "string",
             "format": "email",
-            "example": "alice@example.com"
+            "example": "alice@example.com",
+            "maxLength": 254
           },
           "first_name": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "maxLength": 100
           },
           "last_name": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "maxLength": 100
           },
           "password": {
             "type": "string",
+            "maxLength": 72,
             "minLength": 8
           }
         }


### PR DESCRIPTION
### Location
- backend/router.rs
- backend/platform/identity/auth/auth_api.rs
- backend/platform/shared/api.rs
- backend/test/test_server.rs
- backend/test/platform/identity/auth_tests.rs
- openapi.json
- frontend/src/lib/generated/api.d.ts

### Finding
No request body size limit is enforced. JSON payloads are unbounded. Additionally, there are no max-length validations on password or email fields in RegisterRequest and LoginRequest.

### Risk
Argon2/bcrypt hashing DoS via extremely long passwords, memory exhaustion from parsing large request payloads.

### Recommendation
Add a global request body limit layer (e.g., DefaultBodyLimit::max(2MB)). Add max-length validations (e.g., max = 72 on passwords, max = 254 on email) to DTOs.