### PR TITLE
timeouts for http and oauth clients

### DIFF
--- a/backend/platform/identity/auth/auth_api.rs
+++ b/backend/platform/identity/auth/auth_api.rs
@@ -36,13 +36,23 @@ pub fn router(service: auth::Service) -> utoipax::router::OpenApiRouter<common::
 
 #[derive(Deserialize, validator::Validate, utoipa::ToSchema)]
 pub struct RegisterRequest {
-    #[validate(email(message = "invalid email address"))]
-    #[schema(example = "alice@example.com", format = "email")]
+    #[validate(
+        email(message = "invalid email address"),
+        length(max = 254, message = "email address must be 254 characters or less")
+    )]
+    #[schema(example = "alice@example.com", format = "email", max_length = 254)]
     pub email: String,
-    #[validate(length(min = 8, message = "password must be at least 8 characters"))]
-    #[schema(min_length = 8)]
+
+    #[validate(length(min = 8, max = 72, message = "password must be between 8 and 72 characters"))]
+    #[schema(min_length = 8, max_length = 72)]
     pub password: String,
+
+    #[validate(length(max = 100, message = "first name must be 100 characters or less"))]
+    #[schema(max_length = 100)]
     pub first_name: Option<String>,
+
+    #[validate(length(max = 100, message = "last name must be 100 characters or less"))]
+    #[schema(max_length = 100)]
     pub last_name: Option<String>,
 }
 
@@ -51,10 +61,17 @@ pub struct RegisterResponse {
     pub user: users::api::UserInfo,
 }
 
-#[derive(Deserialize, utoipa::ToSchema)]
+#[derive(Deserialize, validator::Validate, utoipa::ToSchema)]
 pub struct LoginRequest {
-    #[schema(example = "alice@example.com", format = "email")]
+    #[validate(
+        email(message = "invalid email address"),
+        length(max = 254, message = "email address must be 254 characters or less")
+    )]
+    #[schema(example = "alice@example.com", format = "email", max_length = 254)]
     pub email: String,
+
+    #[validate(length(min = 8, max = 72, message = "password must be between 8 and 72 characters"))]
+    #[schema(min_length = 8, max_length = 72)]
     pub password: String,
 }
 
@@ -100,12 +117,13 @@ async fn register(
     request_body = LoginRequest,
     responses(
         (status = 200, description = "Login successful", body = LoginResponse),
+        (status = 400, description = "Validation failed", body = api::Error),
         (status = 401, description = "Invalid credentials", body = api::Error)
     )
 )]
 async fn login(
     State(service): State<auth::Service>,
-    request: api::Json<LoginRequest>,
+    request: api::ValidatedJson<LoginRequest>,
 ) -> Result<impl IntoResponse, api::Error> {
     let request = request.data();
     let email_hash = crypto::get_hash_as_hex(&request.email);

--- a/backend/platform/identity/auth/auth_service.rs
+++ b/backend/platform/identity/auth/auth_service.rs
@@ -159,6 +159,10 @@ impl Service {
             .reset_failed_login_count(&self.context.db, record.user.tenant_id, record.user.id)
             .await?;
 
+        if record.user.status != users::UserStatus::Active {
+            return Err(Error::InvalidCredentials);
+        }
+
         if crypto::needs_rehash(password_hash)? {
             self.update_password_hash(record.user.tenant_id, record.user.id, &command.password)
                 .await;
@@ -177,6 +181,9 @@ impl Service {
             sso_id: command.sso_id,
         };
         let user = self.users.link_sso_user(&self.context.db, cmd).await?;
+        if user.status != users::UserStatus::Active {
+            return Err(Error::InvalidCredentials);
+        }
         self.users
             .reset_failed_login_count(&self.context.db, user.tenant_id, user.id)
             .await?;
@@ -253,6 +260,9 @@ impl Service {
             .users
             .find_by_id(&self.context.db, tenant_id, stored_token.user_id)
             .await?;
+        if user.status != users::UserStatus::Active {
+            return Err(Error::InvalidToken);
+        }
         let access_token = generate_access_token(&self.context, &user)?;
         let refresh_token = generate_refresh_token(&self.context, &user)?;
         let refresh_token_hash = crypto::get_hash_as_hex(&refresh_token.value);

--- a/backend/platform/identity/auth/auth_tests.rs
+++ b/backend/platform/identity/auth/auth_tests.rs
@@ -115,3 +115,45 @@ async fn oauth_user_password_login_failure() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn suspended_user_login_and_refresh_failure() -> TestResult {
+    let ctx = common::Context::create_test_context().await?;
+    let auth_service = auth::Service::new(users::db::Repository, tokens::db::Repository, ctx.clone());
+
+    let email = common::Email::parse("suspended@example.com").ok_or_else(api::Error::invalid_credentials)?;
+    let user = auth_service
+        .register(
+            email.clone(),
+            "super_secure_pass_123".to_string(),
+            Some("Suspended".to_string()),
+            Some("User".to_string()),
+        )
+        .await?;
+
+    // Initial login should succeed when user is active
+    let login_cmd = auth::LoginCommand {
+        email: email.clone(),
+        password: "super_secure_pass_123".to_string(),
+    };
+    let auth_res = auth_service.login(login_cmd.clone()).await?;
+    assert_eq!(auth_res.user.id, user.id);
+
+    // Now suspend the user in the database
+    sqlx::query("UPDATE users SET status = 'suspended' WHERE id = ?")
+        .bind(user.id.0)
+        .execute(&ctx.db)
+        .await?;
+
+    // Subsequent login should fail
+    let login_err = auth_service.login(login_cmd).await;
+    assert!(login_err.is_err());
+    assert!(matches!(login_err, Err(auth::Error::InvalidCredentials)));
+
+    // Refresh should fail
+    let refresh_err = auth_service.refresh(&auth_res.refresh_token.value).await;
+    assert!(refresh_err.is_err());
+    assert!(matches!(refresh_err, Err(auth::Error::InvalidToken)));
+
+    Ok(())
+}

--- a/backend/platform/identity/oauth/oauth_service.rs
+++ b/backend/platform/identity/oauth/oauth_service.rs
@@ -265,7 +265,9 @@ impl Service {
         }
 
         let client = create_google_client(&self.context.settings.oauth)?;
-        let oauth_client = oauth2::reqwest::ClientBuilder::new().build()?;
+        let oauth_client = oauth2::reqwest::ClientBuilder::new()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()?;
 
         let pkce_verifier = oauth2::PkceCodeVerifier::new(token_data.claims.pkce_verifier);
 

--- a/backend/platform/identity/oauth/oauth_service.rs
+++ b/backend/platform/identity/oauth/oauth_service.rs
@@ -265,9 +265,19 @@ impl Service {
         }
 
         let client = create_google_client(&self.context.settings.oauth)?;
-        let oauth_client = oauth2::reqwest::ClientBuilder::new()
-            .timeout(std::time::Duration::from_secs(10))
-            .build()?;
+        let http_client_settings = &self.context.settings.http_client;
+        let mut oauth_client_builder = oauth2::reqwest::ClientBuilder::new();
+        // a configured value of 0 means "no timeout"
+        if http_client_settings.timeout_seconds > 0 {
+            oauth_client_builder =
+                oauth_client_builder.timeout(std::time::Duration::from_secs(http_client_settings.timeout_seconds));
+        }
+        if http_client_settings.connect_timeout_seconds > 0 {
+            oauth_client_builder = oauth_client_builder.connect_timeout(std::time::Duration::from_secs(
+                http_client_settings.connect_timeout_seconds,
+            ));
+        }
+        let oauth_client = oauth_client_builder.build()?;
 
         let pkce_verifier = oauth2::PkceCodeVerifier::new(token_data.claims.pkce_verifier);
 
@@ -283,7 +293,6 @@ impl Service {
             .http_client
             .get("https://www.googleapis.com/oauth2/v2/userinfo")
             .bearer_auth(access_token)
-            .timeout(std::time::Duration::from_secs(10))
             .send()
             .await?
             .error_for_status()?;

--- a/backend/platform/shared/api.rs
+++ b/backend/platform/shared/api.rs
@@ -244,6 +244,7 @@ where
 pub struct Json<T>(pub T);
 
 impl<T> Json<T> {
+    #[allow(dead_code)]
     pub fn data(self) -> T {
         self.0
     }

--- a/backend/platform/shared/api.rs
+++ b/backend/platform/shared/api.rs
@@ -110,6 +110,16 @@ impl Error {
     }
 
     #[must_use]
+    pub fn request_timeout() -> Self {
+        Self::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "request_timeout",
+            "The request took too long to process. Please try again later.",
+            None,
+        )
+    }
+
+    #[must_use]
     pub fn validation_failed(
         field: &str,
         message: &str,

--- a/backend/platform/shared/common.rs
+++ b/backend/platform/shared/common.rs
@@ -82,9 +82,7 @@ impl Context {
     ) -> Result<ArcContext, ContextCreationError> {
         let db = db::create_context(&settings.database).await?;
         let jwt = jwt::create_context(&settings.jwt, jwt_secret);
-        let http_client = reqwest::Client::builder()
-            .redirect(reqwest::redirect::Policy::none())
-            .build()?;
+        let http_client = create_http_client(&settings.http_client)?;
         let context = Self {
             db,
             jwt,
@@ -132,4 +130,16 @@ impl Context {
 
         Ok(context)
     }
+}
+
+fn create_http_client(settings: &config::HttpClientSettings) -> Result<reqwest::Client, reqwest::Error> {
+    let mut builder = reqwest::Client::builder().redirect(reqwest::redirect::Policy::none());
+    // a configured value of 0 means "no timeout"
+    if settings.timeout_seconds > 0 {
+        builder = builder.timeout(std::time::Duration::from_secs(settings.timeout_seconds));
+    }
+    if settings.connect_timeout_seconds > 0 {
+        builder = builder.connect_timeout(std::time::Duration::from_secs(settings.connect_timeout_seconds));
+    }
+    builder.build()
 }

--- a/backend/platform/shared/config.rs
+++ b/backend/platform/shared/config.rs
@@ -24,7 +24,30 @@ pub struct AppSettings {
     pub oauth: OAuthSettings,
 
     #[serde(default)]
+    pub http_client: HttpClientSettings,
+
+    #[serde(default)]
     pub rate_limiter: AppRateLimiterSettings,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct HttpClientSettings {
+    /// Total request timeout in seconds (connect + TLS + response body).
+    #[serde(default)]
+    pub timeout_seconds: u64,
+
+    /// Connection establishment timeout in seconds.
+    #[serde(default)]
+    pub connect_timeout_seconds: u64,
+}
+
+impl Default for HttpClientSettings {
+    fn default() -> Self {
+        Self {
+            timeout_seconds: 10,
+            connect_timeout_seconds: 5,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/backend/platform/shared/config.rs
+++ b/backend/platform/shared/config.rs
@@ -121,6 +121,9 @@ pub struct ServerSettings {
 
     #[serde(default)]
     pub env_vars_prefix: String,
+
+    #[serde(default)]
+    pub trusted_proxy: bool,
 }
 
 impl Default for ServerSettings {
@@ -131,6 +134,7 @@ impl Default for ServerSettings {
             port: 3000,
             log_directives: "info,tower_http=info,axum=info".to_string(),
             env_vars_prefix: "APP".to_string(),
+            trusted_proxy: false,
         }
     }
 }

--- a/backend/platform/shared/rate_limiter.rs
+++ b/backend/platform/shared/rate_limiter.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use axum::http::Request;
 use axum::response::IntoResponse;
@@ -27,6 +28,7 @@ impl tower_governor::key_extractor::KeyExtractor for ClientIpExtractor {
 
 pub static GLOBAL_LIMITER_CONFIG: OnceLock<Arc<GovernorConfig<ClientIpExtractor, NoOpMiddleware>>> = OnceLock::new();
 pub static LOGIN_LIMITER_CONFIG: OnceLock<Arc<GovernorConfig<ClientIpExtractor, NoOpMiddleware>>> = OnceLock::new();
+pub static TRUSTED_PROXY: AtomicBool = AtomicBool::new(false);
 
 pub fn add_global_rate_limiting<S>(
     router: utoipax::router::OpenApiRouter<S>,
@@ -82,18 +84,20 @@ pub fn custom_error_handler(_err: GovernorError) -> Response {
 
 #[must_use]
 pub fn extract_client_ip<B>(req: &Request<B>) -> String {
-    // check common proxy headers
-    if let Some(forwarded_for) = req.headers().get("x-forwarded-for")
-        && let Ok(value) = forwarded_for.to_str()
-        && let Some(ip) = value.split(',').next()
-    {
-        return ip.trim().to_string();
-    }
+    if TRUSTED_PROXY.load(Ordering::Relaxed) {
+        // check common proxy headers
+        if let Some(forwarded_for) = req.headers().get("x-forwarded-for")
+            && let Ok(value) = forwarded_for.to_str()
+            && let Some(ip) = value.split(',').next()
+        {
+            return ip.trim().to_string();
+        }
 
-    if let Some(real_ip) = req.headers().get("x-real-ip")
-        && let Ok(value) = real_ip.to_str()
-    {
-        return value.to_string();
+        if let Some(real_ip) = req.headers().get("x-real-ip")
+            && let Ok(value) = real_ip.to_str()
+        {
+            return value.to_string();
+        }
     }
 
     // fallback to Axum's SocketAddr ConnectInfo

--- a/backend/router.rs
+++ b/backend/router.rs
@@ -74,12 +74,11 @@ pub fn create(context: ArcContext) -> OpenApiRouter {
             }),
         )
         .layer(tower_http::catch_panic::CatchPanicLayer::custom(CustomPanicHandler))
+        // the timeout layer sits inside the security-headers layer so that
+        // timeout responses also carry the security headers
+        .layer(axum::middleware::from_fn(timeout_middleware))
         .layer(axum::middleware::from_fn(security_headers_middleware))
         .layer(axum::extract::DefaultBodyLimit::max(2 * 1024 * 1024))
-        .layer(tower_http::timeout::TimeoutLayer::with_status_code(
-            axum::http::StatusCode::REQUEST_TIMEOUT,
-            std::time::Duration::from_secs(30),
-        ))
         .with_state(context)
 }
 
@@ -186,6 +185,17 @@ fn extract_user_agent(req: &Request<Body>) -> Option<String> {
         .get("user-agent")
         .and_then(|ua| ua.to_str().ok())
         .map(std::string::ToString::to_string)
+}
+
+const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+async fn timeout_middleware(
+    req: Request<Body>,
+    next: axum::middleware::Next,
+) -> Response {
+    tokio::time::timeout(REQUEST_TIMEOUT, next.run(req))
+        .await
+        .unwrap_or_else(|_| api::Error::request_timeout().into_response())
 }
 
 async fn security_headers_middleware(

--- a/backend/router.rs
+++ b/backend/router.rs
@@ -74,6 +74,7 @@ pub fn create(context: ArcContext) -> OpenApiRouter {
             }),
         )
         .layer(tower_http::catch_panic::CatchPanicLayer::custom(CustomPanicHandler))
+        .layer(axum::middleware::from_fn(security_headers_middleware))
         .with_state(context)
 }
 
@@ -180,4 +181,41 @@ fn extract_user_agent(req: &Request<Body>) -> Option<String> {
         .get("user-agent")
         .and_then(|ua| ua.to_str().ok())
         .map(std::string::ToString::to_string)
+}
+
+async fn security_headers_middleware(
+    req: Request<Body>,
+    next: axum::middleware::Next,
+) -> Response {
+    let mut res = next.run(req).await;
+    let headers = res.headers_mut();
+
+    headers.insert(
+        axum::http::header::X_CONTENT_TYPE_OPTIONS,
+        axum::http::HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        axum::http::header::X_FRAME_OPTIONS,
+        axum::http::HeaderValue::from_static("DENY"),
+    );
+    headers.insert(
+        axum::http::header::REFERRER_POLICY,
+        axum::http::HeaderValue::from_static("strict-origin-when-cross-origin"),
+    );
+    headers.insert(
+        axum::http::header::CONTENT_SECURITY_POLICY,
+        axum::http::HeaderValue::from_static(
+            "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'none';",
+        ),
+    );
+    headers.insert(
+        axum::http::header::STRICT_TRANSPORT_SECURITY,
+        axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+    );
+    headers.insert(
+        axum::http::header::HeaderName::from_static("permissions-policy"),
+        axum::http::HeaderValue::from_static("geolocation=(), microphone=(), camera=()"),
+    );
+
+    res
 }

--- a/backend/router.rs
+++ b/backend/router.rs
@@ -75,6 +75,7 @@ pub fn create(context: ArcContext) -> OpenApiRouter {
         )
         .layer(tower_http::catch_panic::CatchPanicLayer::custom(CustomPanicHandler))
         .layer(axum::middleware::from_fn(security_headers_middleware))
+        .layer(axum::extract::DefaultBodyLimit::max(2 * 1024 * 1024))
         .with_state(context)
 }
 

--- a/backend/router.rs
+++ b/backend/router.rs
@@ -27,6 +27,11 @@ pub fn create(context: ArcContext) -> OpenApiRouter {
     use crate::platform::identity::tokens;
     use crate::platform::identity::users;
 
+    rate_limiter::TRUSTED_PROXY.store(
+        context.settings.server.trusted_proxy,
+        std::sync::atomic::Ordering::Relaxed,
+    );
+
     let auth_service = auth::Service::new(users::db::Repository, tokens::db::Repository, context.clone());
     let oauth_service = oauth::Service::new(context.clone(), auth_service.clone());
     let users_service = users::Service::new(users::db::Repository, context.clone());

--- a/backend/router.rs
+++ b/backend/router.rs
@@ -76,6 +76,10 @@ pub fn create(context: ArcContext) -> OpenApiRouter {
         .layer(tower_http::catch_panic::CatchPanicLayer::custom(CustomPanicHandler))
         .layer(axum::middleware::from_fn(security_headers_middleware))
         .layer(axum::extract::DefaultBodyLimit::max(2 * 1024 * 1024))
+        .layer(tower_http::timeout::TimeoutLayer::with_status_code(
+            axum::http::StatusCode::REQUEST_TIMEOUT,
+            std::time::Duration::from_secs(30),
+        ))
         .with_state(context)
 }
 

--- a/backend/test/platform/identity/auth_tests.rs
+++ b/backend/test/platform/identity/auth_tests.rs
@@ -429,7 +429,10 @@ async fn register_invalid_password() -> TestResult {
     response.assert_status(StatusCode::BAD_REQUEST);
     let r: Value = response.json();
     assert_eq!(r["code"], "validation_failed");
-    assert_eq!(r["details"]["password"][0], "password must be at least 8 characters");
+    assert_eq!(
+        r["details"]["password"][0],
+        "password must be between 8 and 72 characters"
+    );
     Ok(())
 }
 

--- a/backend/test/platform/shared/rate_limiter_tests.rs
+++ b/backend/test/platform/shared/rate_limiter_tests.rs
@@ -14,19 +14,35 @@ use crate::platform::rate_limiter::extract_client_ip;
 
 #[test]
 fn test_extract_client_ip() -> Result<(), axum::http::Error> {
-    // test X-Forwarded-For header
+    use std::sync::atomic::Ordering;
+
+    // By default, trusted_proxy is false
+    crate::platform::rate_limiter::TRUSTED_PROXY.store(false, Ordering::Relaxed);
+
+    // test headers ignored when trusted_proxy is false
     let req1 = Request::builder()
         .header("x-forwarded-for", "203.0.113.195, 70.41.3.18, 150.172.238.178")
         .body(())?;
-    assert_eq!(extract_client_ip(&req1), "203.0.113.195");
+    assert_eq!(extract_client_ip(&req1), "unknown");
 
-    // test X-Real-IP header
     let req2 = Request::builder().header("x-real-ip", "203.0.113.196").body(())?;
-    assert_eq!(extract_client_ip(&req2), "203.0.113.196");
+    assert_eq!(extract_client_ip(&req2), "unknown");
+
+    // Enable trusted proxy
+    crate::platform::rate_limiter::TRUSTED_PROXY.store(true, Ordering::Relaxed);
+
+    // test headers honored when trusted_proxy is true
+    let req3 = Request::builder()
+        .header("x-forwarded-for", "203.0.113.195, 70.41.3.18, 150.172.238.178")
+        .body(())?;
+    assert_eq!(extract_client_ip(&req3), "203.0.113.195");
+
+    let req4 = Request::builder().header("x-real-ip", "203.0.113.196").body(())?;
+    assert_eq!(extract_client_ip(&req4), "203.0.113.196");
 
     // test fallback
-    let req3 = Request::builder().body(())?;
-    assert_eq!(extract_client_ip(&req3), "unknown");
+    let req5 = Request::builder().body(())?;
+    assert_eq!(extract_client_ip(&req5), "unknown");
     Ok(())
 }
 

--- a/backend/test/test_server.rs
+++ b/backend/test/test_server.rs
@@ -166,3 +166,46 @@ async fn test_security_headers() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_request_validation() -> TestResult {
+    let server = create_test_server().await?;
+
+    // test password too short in registration (should be 400 Bad Request)
+    let response = server
+        .post("/api/auth/register")
+        .json(&json!({
+            "email": "valid@example.com",
+            "password": "short", // < 8 characters
+            "first_name": "Test",
+            "last_name": "User"
+        }))
+        .await;
+    response.assert_status(StatusCode::BAD_REQUEST);
+    let body: Value = response.json();
+    assert_eq!(body["code"], "validation_failed");
+
+    // test password too long in registration (should be 400 Bad Request)
+    let response_long = server
+        .post("/api/auth/register")
+        .json(&json!({
+            "email": "valid@example.com",
+            "password": "a".repeat(73), // > 72 characters
+            "first_name": "Test",
+            "last_name": "User"
+        }))
+        .await;
+    response_long.assert_status(StatusCode::BAD_REQUEST);
+
+    // test password too long in login (should be 400 Bad Request)
+    let response_login = server
+        .post("/api/auth/login")
+        .json(&json!({
+            "email": "valid@example.com",
+            "password": "a".repeat(73), // > 72 characters
+        }))
+        .await;
+    response_login.assert_status(StatusCode::BAD_REQUEST);
+
+    Ok(())
+}

--- a/backend/test/test_server.rs
+++ b/backend/test/test_server.rs
@@ -143,3 +143,26 @@ async fn test_panic_handling() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_security_headers() -> TestResult {
+    let server = create_test_server().await?;
+
+    let response = server.get("/api/health").await;
+    response.assert_status(StatusCode::OK);
+
+    response.assert_header(axum::http::header::X_CONTENT_TYPE_OPTIONS, "nosniff");
+    response.assert_header(axum::http::header::X_FRAME_OPTIONS, "DENY");
+    response.assert_header(axum::http::header::REFERRER_POLICY, "strict-origin-when-cross-origin");
+    response.assert_header(
+        axum::http::header::CONTENT_SECURITY_POLICY,
+        "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'none';"
+    );
+    response.assert_header(
+        axum::http::header::STRICT_TRANSPORT_SECURITY,
+        "max-age=31536000; includeSubDomains",
+    );
+    response.assert_header("permissions-policy", "geolocation=(), microphone=(), camera=()");
+
+    Ok(())
+}

--- a/code-review-findings/stabilization-plan.md
+++ b/code-review-findings/stabilization-plan.md
@@ -129,19 +129,27 @@ allow — after the cheap, independent work that protects and unblocks it.
 
 No ordering constraints among these; none is invalidated by the Stage B refactor.
 
+### Stage A Pull Requests (Recommended Merge Order)
+The following PRs have been created and stacked to avoid merge conflicts. Please review and merge them in this exact order:
+1. **[PR #284](https://github.com/AndreiBozantan/svelte-axum-template/pull/284)**: `feat(auth): enforce user status check on login and refresh`
+2. **[PR #285](https://github.com/AndreiBozantan/svelte-axum-template/pull/285)**: `feat(security): implement configurable trusted proxy verification for rate limiting`
+3. **[PR #286](https://github.com/AndreiBozantan/svelte-axum-template/pull/286)**: `feat(security): add security response headers middleware layer`
+4. **[PR #287](https://github.com/AndreiBozantan/svelte-axum-template/pull/287)**: `feat(security): enforce global request body limit and body length constraints`
+5. **[PR #288](https://github.com/AndreiBozantan/svelte-axum-template/pull/288)**: `feat(reliability): add global inbound request timeout and Google OAuth client timeout`
+
 Security fixes that don't touch the auth model:
 
 - [ ] Enforce `user.status` on login and refresh; revoke tokens on suspend —
-      [01 § 1.1](01-authentication-session.md#11--suspendedarchived-users-can-still-authenticate-and-refresh) ([#195](https://github.com/AndreiBozantan/svelte-axum-template/issues/195))
+      [01 § 1.1](01-authentication-session.md#11--suspendedarchived-users-can-still-authenticate-and-refresh) ([#195](https://github.com/AndreiBozantan/svelte-axum-template/issues/195)) **(PR: [#284](https://github.com/AndreiBozantan/svelte-axum-template/pull/284))**
 - [ ] Trusted-proxy handling: only honor `X-Forwarded-For`/`X-Real-IP` behind an explicit
       config flag — [01 § 1.3](01-authentication-session.md#13--login-rate-limiter-is-keyed-only-by-client-ip-not-by-account),
-      [05 § 5.3](05-http-transport-security.md#53--global-rate-limit-key-can-be-spoofed-via-forwarding-headers), [19 § 19.3](19-performance-scalability.md#193--rate-limiter-key-maps-grow-unbounded-between-cleanup-ticks) ([#196](https://github.com/AndreiBozantan/svelte-axum-template/issues/196))
+      [05 § 5.3](05-http-transport-security.md#53--global-rate-limit-key-can-be-spoofed-via-forwarding-headers), [19 § 19.3](19-performance-scalability.md#193--rate-limiter-key-maps-grow-unbounded-between-cleanup-ticks) ([#196](https://github.com/AndreiBozantan/svelte-axum-template/issues/196)) **(PR: [#285](https://github.com/AndreiBozantan/svelte-axum-template/pull/285))**
 - [ ] Security response headers (nosniff, frame-ancestors, CSP, HSTS, Referrer-Policy) —
-      [05 § 5.1](05-http-transport-security.md#51--no-security-headers-csp-x-content-type-options-x-frame-options-hsts-referrer-policy-permissions-policy) ([#197](https://github.com/AndreiBozantan/svelte-axum-template/issues/197))
+      [05 § 5.1](05-http-transport-security.md#51--no-security-headers-csp-x-content-type-options-x-frame-options-hsts-referrer-policy-permissions-policy) ([#197](https://github.com/AndreiBozantan/svelte-axum-template/issues/197)) **(PR: [#286](https://github.com/AndreiBozantan/svelte-axum-template/pull/286))**
 - [ ] Request body limit + password/name max-length validation (hash-amplification DoS) —
-      [03 § 3.1/3.2](03-input-validation-injection.md#31--no-request-body-size-limit-json-payloads-are-unbounded) ([#198](https://github.com/AndreiBozantan/svelte-axum-template/issues/198))
+      [03 § 3.1/3.2](03-input-validation-injection.md#31--no-request-body-size-limit-json-payloads-are-unbounded) ([#198](https://github.com/AndreiBozantan/svelte-axum-template/issues/198)) **(PR: [#287](https://github.com/AndreiBozantan/svelte-axum-template/pull/287))**
 - [ ] Request timeout layer; timeout on the OAuth token exchange —
-      [13 § 13.1/13.2](13-error-handling-resilience.md#131--no-timeout-on-inbound-request-handling-or-db-queries) ([#199](https://github.com/AndreiBozantan/svelte-axum-template/issues/199))
+      [13 § 13.1/13.2](13-error-handling-resilience.md#131--no-timeout-on-inbound-request-handling-or-db-queries) ([#199](https://github.com/AndreiBozantan/svelte-axum-template/issues/199)) **(PR: [#288](https://github.com/AndreiBozantan/svelte-axum-template/pull/288))**
 - [ ] Graceful shutdown on SIGTERM (container rollouts) —
       [13 § 13.3](13-error-handling-resilience.md#133--graceful-shutdown-only-listens-for-ctrl-c-not-sigterm) ([#200](https://github.com/AndreiBozantan/svelte-axum-template/issues/200))
 - [ ] Start `docs/design/operations.md` with the mandatory TLS-terminating proxy assumption

--- a/data/configs.common.toml
+++ b/data/configs.common.toml
@@ -30,6 +30,11 @@ google_redirect_uri = "http://localhost:3000/api/oauth/google/callback"
 # Session timeout for OAuth flow (in minutes)
 session_timeout_minutes = 10
 
+# Outbound HTTP client (used for OAuth token exchange and provider userinfo calls)
+[http_client]
+timeout_seconds = 10         # total request budget: connect + TLS + response body; 0 = no timeout
+connect_timeout_seconds = 5  # fail fast when the remote is unreachable; 0 = no timeout
+
 # The rate limiter is backed by the GCRA (Generic Cell Rate Algorithm) token bucket.
 # - rate: The number of requests allowed over the configured period.
 # - period_in_seconds: The duration in seconds of the measurement period.

--- a/data/configs.common.toml
+++ b/data/configs.common.toml
@@ -4,6 +4,7 @@ host = "127.0.0.1"
 port = 3000
 log_directives = "debug,tower_http=debug,axum=debug"
 env_vars_prefix = "APP" # customizable prefix used for the environment variables that override the values provided in the config file
+trusted_proxy = false
 
 [database]
 url = "sqlite:data/db.sqlite"

--- a/data/configs.development.toml
+++ b/data/configs.development.toml
@@ -4,6 +4,7 @@ host = "127.0.0.1"
 port = 3000
 log_directives = "debug,tower_http=debug,axum=debug"
 env_vars_prefix = "APP" # customizable prefix used for the environment variables that override the values provided in the config file
+trusted_proxy = false
 
 [database]
 url = "sqlite:data/db.sqlite"

--- a/data/configs.development.toml
+++ b/data/configs.development.toml
@@ -26,3 +26,8 @@ refresh_token_expiry_days = 32
 google_client_id = ""      # ⚠️ LEAVE EMPTY - set in configs.local.toml or via environment variable
 google_client_secret = ""  # ⚠️ LEAVE EMPTY - set in configs.local.toml or via environment variable
 google_redirect_uri = "http://localhost:3000/api/oauth/google/callback"
+
+# Outbound HTTP client (used for OAuth token exchange and provider userinfo calls)
+[http_client]
+timeout_seconds = 10         # total request budget: connect + TLS + response body; 0 = no timeout
+connect_timeout_seconds = 5  # fail fast when the remote is unreachable; 0 = no timeout

--- a/data/configs.production.toml
+++ b/data/configs.production.toml
@@ -4,6 +4,7 @@ host = "0.0.0.0"
 port = 3000
 log_directives = "info,tower_http=warn,axum=warn"
 env_vars_prefix = "APP" # customizable prefix used for the environment variables that override the values provided in the config file
+trusted_proxy = false
 
 [database]
 url = "sqlite:data/db.sqlite"

--- a/data/configs.production.toml
+++ b/data/configs.production.toml
@@ -29,3 +29,8 @@ google_redirect_uri = ""   # 🚀 add your actual redirect URI here
 
 # Session timeout for OAuth flow (in minutes) - shorter for production
 session_timeout_minutes = 5
+
+# Outbound HTTP client (used for OAuth token exchange and provider userinfo calls)
+[http_client]
+timeout_seconds = 10         # total request budget: connect + TLS + response body; 0 = no timeout
+connect_timeout_seconds = 5  # fail fast when the remote is unreachable; 0 = no timeout

--- a/frontend/src/lib/generated/api.d.ts
+++ b/frontend/src/lib/generated/api.d.ts
@@ -299,6 +299,15 @@ export interface operations {
                     'application/json': components['schemas']['LoginResponse'];
                 };
             };
+            /** @description Validation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    'application/json': components['schemas']['ApiError'];
+                };
+            };
             /** @description Invalid credentials */
             401: {
                 headers: {

--- a/openapi.json
+++ b/openapi.json
@@ -55,6 +55,16 @@
               }
             }
           },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Invalid credentials",
             "content": {
@@ -490,10 +500,13 @@
           "email": {
             "type": "string",
             "format": "email",
-            "example": "alice@example.com"
+            "example": "alice@example.com",
+            "maxLength": 254
           },
           "password": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 72,
+            "minLength": 8
           }
         }
       },
@@ -541,22 +554,26 @@
           "email": {
             "type": "string",
             "format": "email",
-            "example": "alice@example.com"
+            "example": "alice@example.com",
+            "maxLength": 254
           },
           "first_name": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "maxLength": 100
           },
           "last_name": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "maxLength": 100
           },
           "password": {
             "type": "string",
+            "maxLength": 72,
             "minLength": 8
           }
         }


### PR DESCRIPTION
### Location
- backend/router.rs
- backend/platform/identity/oauth/oauth_service.rs

### Finding
No request timeout layer is registered on inbound requests or outbound database queries. Additionally, reqwest calls during OAuth token exchange have no timeouts set.

### Risk
Lingering/leaked connections from slow clients, resource exhaustion (Tokio worker starvation) if downstream services (like Google OAuth API) are unresponsive or slow.

### Recommendation
Add a TimeoutLayer to the Axum application (e.g. 30 seconds). Add explicit timeouts (e.g. 10 seconds) on reqwest calls.