### PR TITLE
remove unsafe-inline/unsafe-eval from script-src CSP

### DIFF
--- a/backend/router.rs
+++ b/backend/router.rs
@@ -205,7 +205,7 @@ async fn security_headers_middleware(
     headers.insert(
         axum::http::header::CONTENT_SECURITY_POLICY,
         axum::http::HeaderValue::from_static(
-            "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'none';",
+            "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none';",
         ),
     );
     headers.insert(

--- a/backend/test/test_server.rs
+++ b/backend/test/test_server.rs
@@ -156,7 +156,7 @@ async fn test_security_headers() -> TestResult {
     response.assert_header(axum::http::header::REFERRER_POLICY, "strict-origin-when-cross-origin");
     response.assert_header(
         axum::http::header::CONTENT_SECURITY_POLICY,
-        "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-ancestors 'none';"
+        "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none';"
     );
     response.assert_header(
         axum::http::header::STRICT_TRANSPORT_SECURITY,


### PR DESCRIPTION
## Summary

Completes PR #286, which was merged before its final commit was included.
This PR contains only that missing commit (c93f970), tightening the
Content-Security-Policy added by the security headers middleware.

## Changes

- Remove `'unsafe-inline'` and `'unsafe-eval'` from the `script-src` CSP
  directive, leaving `script-src 'self'`
- Update the `test_security_headers` assertion to match

## Why

With `'unsafe-inline'` in `script-src`, any injected `<script>` tag executes,
so the CSP provides essentially no XSS protection. `'unsafe-eval'` additionally
permits `eval()` / `new Function()`. Neither is needed: the production Vite
build of the Svelte 5 SPA emits only external `.js` files and does not use
`eval`. The `'unsafe-inline'` allowance in `style-src` is kept intentionally.

## Testing

- `test_security_headers` asserts the exact tightened CSP header value