### PR TITLE
PatriciaBratu/fix background cleanup

### DIFF
--- a/backend/server.rs
+++ b/backend/server.rs
@@ -119,33 +119,79 @@ fn get_log_directives(settings: &config::AppSettings) -> String {
 }
 
 fn start_background_cleanup_tasks(ctx: &common::ArcContext) {
-    // expired refresh tokens cleanup task
     let db = ctx.db.clone();
-    tokio::spawn(async move {
-        let mut ticker = tokio::time::interval(std::time::Duration::from_hours(1));
-        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
+    tokio::spawn(async move {
         loop {
-            ticker.tick().await;
-            perform_refresh_tokens_cleanup(&db).await;
+            let db_clone = db.clone();
+
+            let handle = tokio::spawn(run_refresh_tokens_loop(db_clone));
+
+            match handle.await {
+                Ok(_) => {
+                    error!("Task-ul de curățare token-uri a ieșit neașteptat din buclă. Se încearcă repornirea...");
+                },
+                Err(join_err) => {
+                    if join_err.is_panic() {
+                        error!(
+                            "CRITICAL: Task-ul de curățare token-uri a suferit un PANIC! Se încearcă recuperarea și repornirea..."
+                        );
+                    } else {
+                        error!(error = %join_err, "Task-ul de curățare token-uri a fost anulat/oprit forțat. Se încearcă repornirea...");
+                    }
+                },
+            }
+
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         }
     });
 
-    // expired rate limiter keys cleanup task
     tokio::spawn(async move {
-        let mut ticker = tokio::time::interval(std::time::Duration::from_mins(15));
-        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
         loop {
-            ticker.tick().await;
-            if let Some(config) = crate::platform::rate_limiter::GLOBAL_LIMITER_CONFIG.get() {
-                config.limiter().retain_recent();
+            let handle = tokio::spawn(run_rate_limiter_loop());
+
+            match handle.await {
+                Ok(_) => {
+                    error!("Task-ul de rate limiter a ieșit neașteptat din buclă. Se încearcă repornirea...");
+                },
+                Err(join_err) => {
+                    if join_err.is_panic() {
+                        error!(
+                            "CRITICAL: Task-ul de rate limiter a suferit un PANIC! Se încearcă recuperarea și repornirea..."
+                        );
+                    } else {
+                        error!(error = %join_err, "Task-ul de rate limiter a fost anulat/oprit forțat. Se încearcă repornirea...");
+                    }
+                },
             }
-            if let Some(config) = crate::platform::rate_limiter::LOGIN_LIMITER_CONFIG.get() {
-                config.limiter().retain_recent();
-            }
+
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         }
     });
+}
+async fn run_refresh_tokens_loop(db: crate::platform::db::Context) {
+    let mut ticker = tokio::time::interval(std::time::Duration::from_hours(1));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        ticker.tick().await;
+        perform_refresh_tokens_cleanup(&db).await;
+    }
+}
+
+async fn run_rate_limiter_loop() {
+    let mut ticker = tokio::time::interval(std::time::Duration::from_mins(15));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        ticker.tick().await;
+        if let Some(config) = crate::platform::rate_limiter::GLOBAL_LIMITER_CONFIG.get() {
+            config.limiter().retain_recent();
+        }
+        if let Some(config) = crate::platform::rate_limiter::LOGIN_LIMITER_CONFIG.get() {
+            config.limiter().retain_recent();
+        }
+    }
 }
 
 async fn perform_refresh_tokens_cleanup(db: &crate::platform::db::Context) {

--- a/backend/server.rs
+++ b/backend/server.rs
@@ -128,7 +128,7 @@ fn start_background_cleanup_tasks(ctx: &common::ArcContext) {
             let handle = tokio::spawn(run_refresh_tokens_loop(db_clone));
 
             match handle.await {
-                Ok(_) => {
+                Ok(()) => {
                     error!("Task-ul de curățare token-uri a ieșit neașteptat din buclă. Se încearcă repornirea...");
                 },
                 Err(join_err) => {
@@ -151,7 +151,7 @@ fn start_background_cleanup_tasks(ctx: &common::ArcContext) {
             let handle = tokio::spawn(run_rate_limiter_loop());
 
             match handle.await {
-                Ok(_) => {
+                Ok(()) => {
                     error!("Task-ul de rate limiter a ieșit neașteptat din buclă. Se încearcă repornirea...");
                 },
                 Err(join_err) => {

--- a/backend/server.rs
+++ b/backend/server.rs
@@ -155,8 +155,8 @@ fn start_background_cleanup_tasks(ctx: &common::ArcContext) {
     spawn_supervised_task("refresh_tokens_cleanup_task", move || {
         run_refresh_tokens_cleanup_loop(db.clone())
     });
-    #[allow(clippy::redundant_closure)]
-    spawn_supervised_task("rate_limiter_cleanup_task", || run_rate_limiter_cleanup_loop());
+    spawn_supervised_task("rate_limiter_cleanup_task", run_rate_limiter_cleanup_loop);
+
 }
 
 fn spawn_supervised_task<F, Fut>(task_name: &'static str, task_factory: F)

--- a/backend/server.rs
+++ b/backend/server.rs
@@ -117,83 +117,6 @@ fn get_log_directives(settings: &config::AppSettings) -> String {
         settings.server.log_directives.clone()
     }
 }
-
-fn start_background_cleanup_tasks(ctx: &common::ArcContext) {
-    let db = ctx.db.clone();
-
-    tokio::spawn(async move {
-        loop {
-            let db_clone = db.clone();
-
-            let handle = tokio::spawn(run_refresh_tokens_loop(db_clone));
-
-            match handle.await {
-                Ok(()) => {
-                    error!("Task-ul de curățare token-uri a ieșit neașteptat din buclă. Se încearcă repornirea...");
-                },
-                Err(join_err) => {
-                    if join_err.is_panic() {
-                        error!(
-                            "CRITICAL: Task-ul de curățare token-uri a suferit un PANIC! Se încearcă recuperarea și repornirea..."
-                        );
-                    } else {
-                        error!(error = %join_err, "Task-ul de curățare token-uri a fost anulat/oprit forțat. Se încearcă repornirea...");
-                    }
-                },
-            }
-
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-        }
-    });
-
-    tokio::spawn(async move {
-        loop {
-            let handle = tokio::spawn(run_rate_limiter_loop());
-
-            match handle.await {
-                Ok(()) => {
-                    error!("Task-ul de rate limiter a ieșit neașteptat din buclă. Se încearcă repornirea...");
-                },
-                Err(join_err) => {
-                    if join_err.is_panic() {
-                        error!(
-                            "CRITICAL: Task-ul de rate limiter a suferit un PANIC! Se încearcă recuperarea și repornirea..."
-                        );
-                    } else {
-                        error!(error = %join_err, "Task-ul de rate limiter a fost anulat/oprit forțat. Se încearcă repornirea...");
-                    }
-                },
-            }
-
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-        }
-    });
-}
-async fn run_refresh_tokens_loop(db: crate::platform::db::Context) {
-    let mut ticker = tokio::time::interval(std::time::Duration::from_hours(1));
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-    loop {
-        ticker.tick().await;
-        perform_refresh_tokens_cleanup(&db).await;
-    }
-}
-
-async fn run_rate_limiter_loop() {
-    let mut ticker = tokio::time::interval(std::time::Duration::from_mins(15));
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-    loop {
-        ticker.tick().await;
-        if let Some(config) = crate::platform::rate_limiter::GLOBAL_LIMITER_CONFIG.get() {
-            config.limiter().retain_recent();
-        }
-        if let Some(config) = crate::platform::rate_limiter::LOGIN_LIMITER_CONFIG.get() {
-            config.limiter().retain_recent();
-        }
-    }
-}
-
 async fn perform_refresh_tokens_cleanup(db: &crate::platform::db::Context) {
     let now = chrono::Utc::now().naive_utc();
 
@@ -209,6 +132,73 @@ async fn perform_refresh_tokens_cleanup(db: &crate::platform::db::Context) {
                 "expired_refresh_tokens_cleanup_failed"
             );
         },
+    }
+}
+async fn run_rate_limiter_cleanup_loop() {
+    let mut ticker = tokio::time::interval(std::time::Duration::from_mins(15));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        ticker.tick().await;
+        if let Some(config) = crate::platform::rate_limiter::GLOBAL_LIMITER_CONFIG.get() {
+            config.limiter().retain_recent();
+        }
+        if let Some(config) = crate::platform::rate_limiter::LOGIN_LIMITER_CONFIG.get() {
+            config.limiter().retain_recent();
+        }
+    }
+}
+
+fn start_background_cleanup_tasks(ctx: &common::ArcContext) {
+    let db = ctx.db.clone();
+
+    spawn_supervised_task("refresh_tokens_cleanup_task", move || {
+        run_refresh_tokens_cleanup_loop(db.clone())
+    });
+    #[allow(clippy::redundant_closure)]
+    spawn_supervised_task("rate_limiter_cleanup_task", || run_rate_limiter_cleanup_loop());
+}
+
+fn spawn_supervised_task<F, Fut>(
+    task_name: &'static str,
+    task_factory: F,
+) where
+    F: Fn() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        loop {
+            let handle = tokio::spawn(task_factory());
+
+            match handle.await {
+                Ok(()) => {
+                    error!("{} exited unexpectedly. Attempting to restart...", task_name);
+                },
+                Err(join_err) => {
+                    if join_err.is_panic() {
+                        error!("CRITICAL: {} panicked! Attempting to recover and restart...", task_name);
+                    } else {
+                        error!(
+                            error = %join_err,
+                            "{} was cancelled/forcefully stopped. Attempting to restart...",
+                            task_name
+                        );
+                    }
+                },
+            }
+
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        }
+    });
+}
+
+async fn run_refresh_tokens_cleanup_loop(db: crate::platform::db::Context) {
+    let mut ticker = tokio::time::interval(std::time::Duration::from_hours(1));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        ticker.tick().await;
+        perform_refresh_tokens_cleanup(&db).await;
     }
 }
 

--- a/backend/server.rs
+++ b/backend/server.rs
@@ -159,34 +159,19 @@ fn start_background_cleanup_tasks(ctx: &common::ArcContext) {
     spawn_supervised_task("rate_limiter_cleanup_task", || run_rate_limiter_cleanup_loop());
 }
 
-fn spawn_supervised_task<F, Fut>(
-    task_name: &'static str,
-    task_factory: F,
-) where
+fn spawn_supervised_task<F, Fut>(task_name: &'static str, task_factory: F)
+where
     F: Fn() -> Fut + Send + 'static,
     Fut: std::future::Future<Output = ()> + Send + 'static,
 {
     tokio::spawn(async move {
         loop {
-            let handle = tokio::spawn(task_factory());
-
-            match handle.await {
-                Ok(()) => {
-                    error!("{} exited unexpectedly. Attempting to restart...", task_name);
-                },
-                Err(join_err) => {
-                    if join_err.is_panic() {
-                        error!("CRITICAL: {} panicked! Attempting to recover and restart...", task_name);
-                    } else {
-                        error!(
-                            error = %join_err,
-                            "{} was cancelled/forcefully stopped. Attempting to restart...",
-                            task_name
-                        );
-                    }
-                },
-            }
-
+            let reason = match tokio::spawn(task_factory()).await {
+                Ok(()) => "exited unexpectedly".to_string(),
+                Err(e) if e.is_panic() => "panicked".to_string(),
+                Err(e) => format!("was cancelled/forcefully stopped: {e}"),
+            };
+            error!("{task_name} {reason}. Restarting...");
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         }
     });


### PR DESCRIPTION
### Context
This Draft PR addresses the issue mentioned in the code review under point **13.4 — Background cleanup tasks have no restart/panic handling**.
Previously, the cleanup tasks for refresh-tokens and the rate-limiter were running in a simple `tokio::spawn`. If a `panic!` occurred, the thread would die silently, and the cleanup would never be performed again during the server's lifetime, without leaving any trace in the logs.

### Implemented Solution
I introduced a "Supervisor" pattern to ensure the resilience of these tasks:
* Extracted the cleanup logic from inside the macros into dedicated asynchronous functions (`run_refresh_tokens_loop` and `run_rate_limiter_loop`) for better clarity.
* Wrapped the execution of each task in an infinite `loop` within the `start_background_cleanup_tasks` function.
* By using `.await` on the `JoinHandle` returned by the worker, I now catch any unexpected exits.
* If the result is `Err(JoinError)`, I use `join_err.is_panic()` to differentiate a normal cancellation from a *panic!* and log the event at the appropriate level (`error!`).
* Added a 5-second `tokio::time::sleep` before respawning, to prevent an aggressive *restart loop* that would unnecessarily consume CPU in case of a persistent database error.
* *Update:* Also resolved the linting warning raised by Clippy (`ignored_unit_patterns`) by using `Ok(())` instead of `Ok(_)`.

### Definition of Done
- [x] Ran `cargo clippy --workspace --all-targets` (0 warnings/errors)
- [x] Ran `cargo test` (all tests pass successfully)

Looking forward to your feedback on whether this approach is okay or if anything needs to be refined before marking it as *Ready for review*!