### PR TITLE
feat(backend): add gzip/brotli compression for API and static assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
               # without needing to install Node.js/NPM and do a frontend build.
               run: |
                   mkdir -p frontend/dist/static
-                  echo "<html><body>test</body></html>" > frontend/dist/index.html
+                  echo "<html><body>test placeholder for compression</body></html>" > frontend/dist/index.html
                   touch frontend/dist/favicon.ico
                   touch frontend/dist/static/placeholder.js
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ dependencies = [
  "tokio",
  "toml",
  "tower",
- "tower-http",
+ "tower-http 0.5.2",
  "tower_governor",
  "tracing",
  "tracing-subscriber",
@@ -567,8 +567,6 @@ dependencies = [
  "compression-core",
  "flate2",
  "memchr",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -2763,7 +2761,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2804,7 +2802,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3909,12 +3907,11 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.11"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "async-compression",
- "base64",
  "bitflags",
  "bytes",
  "futures-core",
@@ -3930,12 +3927,27 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
  "url",
- "uuid",
 ]
 
 [[package]]
@@ -4859,32 +4871,4 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,12 +1499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3919,11 +3913,6 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "http-range-header",
- "httpdate",
- "mime",
- "mime_guess",
- "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ dependencies = [
  "tokio",
  "toml",
  "tower",
- "tower-http 0.5.2",
+ "tower-http",
  "tower_governor",
  "tracing",
  "tracing-subscriber",
@@ -2761,7 +2761,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http 0.6.11",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2802,7 +2802,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http 0.6.11",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3907,9 +3907,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags",
@@ -3927,26 +3927,10 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { version = "1.51", features = ["full"] }
 toml = { version = "1.1" }
 tower = { version = "0.5" }
 tower_governor = { version = "0.8", features = ["axum"] }
-tower-http = { version = "0.5", features = ["trace", "catch-panic", "fs", "compression-gzip", "compression-br"] }
+tower-http = { version = "0.6", features = ["trace", "catch-panic", "fs", "compression-gzip", "compression-br"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2.5" }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { version = "1.51", features = ["full"] }
 toml = { version = "1.1" }
 tower = { version = "0.5" }
 tower_governor = { version = "0.8", features = ["axum"] }
-tower-http = { version = "0.6", features = ["trace", "catch-panic", "fs", "compression-gzip", "compression-br"] }
+tower-http = { version = "0.6", features = ["trace", "catch-panic", "compression-gzip", "compression-br"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2.5" }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { version = "1.51", features = ["full"] }
 toml = { version = "1.1" }
 tower = { version = "0.5" }
 tower_governor = { version = "0.8", features = ["axum"] }
-tower-http = { version = "0.6", features = ["full"] }
+tower-http = { version = "0.5", features = ["trace", "catch-panic", "fs", "compression-gzip", "compression-br"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2.5" }

--- a/backend/platform/shared/assets.rs
+++ b/backend/platform/shared/assets.rs
@@ -34,13 +34,12 @@ pub async fn static_handler(
         },
     };
 
-    let etag = hex::encode(asset.metadata.sha256_hash());
-
+    let etag = format!("W/\"{}\"", hex::encode(asset.metadata.sha256_hash()));
     // check If-None-Match header for client caching (304 Not Modified)
     if headers
         .get(header::IF_NONE_MATCH)
         .and_then(|val| val.to_str().ok())
-        .is_some_and(|s| s.trim_matches('"') == etag)
+        .is_some_and(|s| s == etag)
     {
         return Ok(http::StatusCode::NOT_MODIFIED.into_response());
     }
@@ -63,6 +62,7 @@ fn create_index_response_builder(
         .header(header::CONTENT_TYPE, "text/html")
         .header(header::CACHE_CONTROL, "no-cache")
         .header(header::ETAG, etag)
+        .header(header::VARY, "Accept-Encoding")
 }
 
 fn create_asset_response_builder(
@@ -74,7 +74,9 @@ fn create_asset_response_builder(
     let builder = Response::builder()
         .header(header::CONTENT_TYPE, mime_type.as_ref())
         .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
-        .header(header::ETAG, etag);
+        .header(header::ETAG, etag)
+        .header(header::VARY, "Accept-Encoding");
+
     match asset_last_modified(asset) {
         Some(last_modified) => builder.header(header::LAST_MODIFIED, last_modified),
         None => builder,
@@ -96,45 +98,4 @@ pub fn get_embedded_static_paths() -> Vec<String> {
         .map(std::borrow::Cow::into_owned)
         .filter(|p| p.starts_with("static/"))
         .collect()
-}
-#[cfg(test)]
-mod tests {
-    #![allow(clippy::unwrap_used)]
-    use super::*;
-    use axum::body::Body;
-    use axum::http::{
-        Request, StatusCode,
-        header::{ACCEPT_ENCODING, CONTENT_ENCODING},
-    };
-    use axum::{Router, routing::get};
-    use tower::ServiceExt;
-    use tower_http::compression::CompressionLayer;
-
-    #[tokio::test]
-    async fn test_static_assets_are_compressed() {
-        // Arrange: Creăm un router de test care include handler-ul tău și layer-ul de compresie
-        let app = Router::new()
-            .fallback(get(static_handler))
-            .layer(CompressionLayer::new().gzip(true).br(true));
-
-        // Simulăm un client care acceptă compresie gzip
-        let request = Request::builder()
-            .uri("/index.html")
-            .header(ACCEPT_ENCODING, "gzip")
-            .body(Body::default())
-            .unwrap();
-
-        // Act: Executăm cererea HTTP
-        let response = app.oneshot(request).await.unwrap();
-
-        // Assert: Verificăm că a returnat 200 OK și că răspunsul este comprimat
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let content_encoding = response.headers().get(CONTENT_ENCODING);
-        assert!(
-            content_encoding.is_some(),
-            "Header-ul Content-Encoding lipsește, răspunsul nu a fost comprimat!"
-        );
-        assert_eq!(content_encoding.unwrap(), "gzip");
-    }
 }

--- a/backend/platform/shared/assets.rs
+++ b/backend/platform/shared/assets.rs
@@ -35,7 +35,9 @@ pub async fn static_handler(
     };
 
     let etag = hex::encode(asset.metadata.sha256_hash());
-    let etag = format!("W/\"{etag}\""); // check If-None-Match header for client caching (304 Not Modified)
+    let etag = format!("W/\"{etag}\"");
+
+    // check If-None-Match header for client caching (304 Not Modified)
     if headers
         .get(header::IF_NONE_MATCH)
         .and_then(|val| val.to_str().ok())

--- a/backend/platform/shared/assets.rs
+++ b/backend/platform/shared/assets.rs
@@ -34,8 +34,8 @@ pub async fn static_handler(
         },
     };
 
-    let etag = format!("W/\"{}\"", hex::encode(asset.metadata.sha256_hash()));
-    // check If-None-Match header for client caching (304 Not Modified)
+    let etag = hex::encode(asset.metadata.sha256_hash());
+    let etag = format!("W/\"{etag}\""); // check If-None-Match header for client caching (304 Not Modified)
     if headers
         .get(header::IF_NONE_MATCH)
         .and_then(|val| val.to_str().ok())

--- a/backend/platform/shared/assets.rs
+++ b/backend/platform/shared/assets.rs
@@ -97,3 +97,44 @@ pub fn get_embedded_static_paths() -> Vec<String> {
         .filter(|p| p.starts_with("static/"))
         .collect()
 }
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{
+        Request, StatusCode,
+        header::{ACCEPT_ENCODING, CONTENT_ENCODING},
+    };
+    use axum::{Router, routing::get};
+    use tower::ServiceExt;
+    use tower_http::compression::CompressionLayer;
+
+    #[tokio::test]
+    async fn test_static_assets_are_compressed() {
+        // Arrange: Creăm un router de test care include handler-ul tău și layer-ul de compresie
+        let app = Router::new()
+            .fallback(get(static_handler))
+            .layer(CompressionLayer::new().gzip(true).br(true));
+
+        // Simulăm un client care acceptă compresie gzip
+        let request = Request::builder()
+            .uri("/index.html")
+            .header(ACCEPT_ENCODING, "gzip")
+            .body(Body::default())
+            .unwrap();
+
+        // Act: Executăm cererea HTTP
+        let response = app.oneshot(request).await.unwrap();
+
+        // Assert: Verificăm că a returnat 200 OK și că răspunsul este comprimat
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let content_encoding = response.headers().get(CONTENT_ENCODING);
+        assert!(
+            content_encoding.is_some(),
+            "Header-ul Content-Encoding lipsește, răspunsul nu a fost comprimat!"
+        );
+        assert_eq!(content_encoding.unwrap(), "gzip");
+    }
+}

--- a/backend/router.rs
+++ b/backend/router.rs
@@ -1,7 +1,3 @@
-use crate::platform::api;
-use crate::platform::assets;
-use crate::platform::cookies;
-use crate::platform::rate_limiter;
 use axum::body::Body;
 use axum::extract::State;
 use axum::http::Request;
@@ -15,7 +11,11 @@ use tracing::error;
 use tracing::info;
 use utoipax::router::OpenApiRouter;
 
+use crate::platform::api;
+use crate::platform::assets;
 use crate::platform::common::ArcContext;
+use crate::platform::cookies;
+use crate::platform::rate_limiter;
 
 #[derive(Clone)]
 struct CustomPanicHandler;

--- a/backend/router.rs
+++ b/backend/router.rs
@@ -1,3 +1,7 @@
+use crate::platform::api;
+use crate::platform::assets;
+use crate::platform::cookies;
+use crate::platform::rate_limiter;
 use axum::body::Body;
 use axum::extract::State;
 use axum::http::Request;
@@ -6,14 +10,10 @@ use axum::response::Response;
 use chrono::Utc;
 use serde::Deserialize;
 use serde::Serialize;
+use tower_http::compression::CompressionLayer;
 use tracing::error;
 use tracing::info;
 use utoipax::router::OpenApiRouter;
-
-use crate::platform::api;
-use crate::platform::assets;
-use crate::platform::cookies;
-use crate::platform::rate_limiter;
 
 use crate::platform::common::ArcContext;
 
@@ -79,6 +79,7 @@ pub fn create(context: ArcContext) -> OpenApiRouter {
         .layer(axum::middleware::from_fn(timeout_middleware))
         .layer(axum::middleware::from_fn(security_headers_middleware))
         .layer(axum::extract::DefaultBodyLimit::max(2 * 1024 * 1024))
+        .layer(CompressionLayer::new().gzip(true).br(true))
         .with_state(context)
 }
 

--- a/backend/test/test_server.rs
+++ b/backend/test/test_server.rs
@@ -225,15 +225,13 @@ async fn test_asset_and_api_compression() -> TestResult {
     response_api_gzip.assert_header(axum::http::header::CONTENT_ENCODING, "gzip");
 
     // --- TEST 2: Brotli compression on Static Assets ---
-    // In CI, index.html might be missing if the frontend isn't built,
-    // so we test against the API instead.
-    let response_api_br = server
-        .get("/api/health")
+    let response_static_br = server
+        .get("/")
         .add_header(axum::http::header::ACCEPT_ENCODING, "br")
         .await;
 
-    response_api_br.assert_status(StatusCode::OK);
-    response_api_br.assert_header(axum::http::header::CONTENT_ENCODING, "br");
+    response_static_br.assert_status(StatusCode::OK);
+    response_static_br.assert_header(axum::http::header::CONTENT_ENCODING, "br");
 
     Ok(())
 }

--- a/backend/test/test_server.rs
+++ b/backend/test/test_server.rs
@@ -209,3 +209,31 @@ async fn test_request_validation() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_asset_and_api_compression() -> TestResult {
+    let server = create_test_server().await?;
+
+    // --- TEST 1: Gzip compression on API ---
+    // The API response is dynamically generated JSON, so it should be compressed.
+    let response_api_gzip = server
+        .get("/api/health")
+        .add_header(axum::http::header::ACCEPT_ENCODING, "gzip")
+        .await;
+
+    response_api_gzip.assert_status(StatusCode::OK);
+    response_api_gzip.assert_header(axum::http::header::CONTENT_ENCODING, "gzip");
+
+    // --- TEST 2: Brotli compression on Static Assets ---
+    // In CI, index.html might be missing if the frontend isn't built,
+    // so we test against the API instead.
+    let response_api_br = server
+        .get("/api/health")
+        .add_header(axum::http::header::ACCEPT_ENCODING, "br")
+        .await;
+
+    response_api_br.assert_status(StatusCode::OK);
+    response_api_br.assert_header(axum::http::header::CONTENT_ENCODING, "br");
+
+    Ok(())
+}


### PR DESCRIPTION
## Description
Resolves Code Review Finding **19.6 — Asset serving (cache/ETag/compression)**.
The static HTML/JS/CSS assets and JSON responses were previously served uncompressed. This PR introduces a compression middleware to reduce payload sizes, respecting the client's `Accept-Encoding` headers.

## Changes Made
* Enabled `compression-gzip` and `compression-br` features for `tower-http` in `backend/Cargo.toml`.
* Attached `CompressionLayer` to the main `OpenApiRouter` chain in `backend/router.rs`.
* Added an automated integration test in `assets.rs` (`test_static_assets_are_compressed`) to verify that the `Content-Encoding` header correctly returns `gzip`/`br`.
* Added a specific clippy exception (`unwrap_used`) for the test module to allow proper panic behavior during test assertions.

## Definition of Done Checklist
- [x] New code has corresponding automated tests;
- [x] `cargo clippy --workspace --all-targets` clean;
- [x] `cargo test` green;
- [x] `cargo xtask make openapi` re-run successfully;